### PR TITLE
Set environment var MIX_TARGET in the firmware mix.exs file.

### DIFF
--- a/apps/fw/mix.exs
+++ b/apps/fw/mix.exs
@@ -6,6 +6,8 @@ defmodule Fw.MixProject do
              _ -> "host"
            end)
 
+  System.put_env("MIX_TARGET", @target)
+
   Mix.shell().info([
     :green,
     """


### PR DESCRIPTION
MIX_TARGET environment variable used to be only be read in the generated firmware mix.exs file. Now it is used elsewhere in the toolchain and determines whether to compile C extensions.

This quick fix ensures it matches the target in the firmware mix file, even if the environment variable isn't set.