### PR TITLE
Some instructions on Wifi connecting and discovering the Pi's IP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,47 @@ Start by running
 iex -S mix phx.server
 ```
 
-## Todo / Ideas
+## Deploying on to the Raspberry Pi
 
-* Use MDNS so we know the control IP.
-* More controls (kick)
-* Better designed controls
+```
+cp apps/wifi/config/config.secret.example.exs apps/wifi/config/config.secret.exs
+```
+
+Ideally edit `config.secret.exs` to match your WiFi settings. As this application connects to Marty over the Wifi then Marty must also be on the same network.
+
+Ensure you are set up for Nerves deployment. Instructions are [here](https://kapeli.com/dash_share?docset_file=nerves&docset_name=nerves&path=docs/installation.html&platform=hex&repo=Hex%20Docsets&version=1.0.0-rc.1).
+
+Add the SD card to whatever card reader/writer you are using on your development box.
+
+```
+cd apps/fw
+export MIX_ENV=prod
+mix firmware
+mix firmware.burn
+```
+
+Marty's Pi should boot from the SD card.
+
+## Wifi special instructions
+
+_There are special issues when working in the Cultivate office_: the office network can be pants with the Pi zeros. As of the end of March 2018 no Pi Zero could connect to the Cultivate SSID, though they could connect to  "CodeBASE - Visitor"; this changes periodically and is not predictable. Overall it is more reliable to use a different wireless router.
+
+See [apps/wifi/README.md](apps/wifi/README.md) for instructions on switching. Changing Marty's microprocessor board (aka Rick) to match the Pi network, necessary for the connection between the Pi and Marty, is documented on the [Robotical](https://robotical.io) website. As I write this I don't have a good internet connection so can't link to the exact page. From memory, to change Marty's WiFi settings:
+
+* Find Bob the Button on Marty's board and hold for 10 seconds. Marty will make funny sounds.
+* Look for an unsecured network called something like "Marty Setup" and join.
+* Open [http://192.168.4.1](http://192.168.4.1)
+* Follow the instructions
+
+## The many ways of finding Marty's Pi
+
+1. Once on a network, Marty's Pi ought to be found on http://marty.local, thanks to the wonders of MDNS. However this does not always work; it works in my house but not in the Cultivate office. ¯\\_(ツ)_/¯
+1. Remember if the Pi is not on the wireless network then it won't be findable. As per the instructions in [apps/wifi/README.md](apps/wifi/README.md) connecting over serial USB with `screen` is a good way to investigate. `:inet.getifaddrs()` will list all the current IP addresses.
+1. You can scan with `nmap` for the image server port being open: `nmap -p 4500 | grep -B 4 open`
+
+There is another marvelous way to find the IP, but I do not have room in this margin to write it. Let's just say that the following might be worth a shot.
+
+```
+cd apps/wifi
+iex --name mirabilis --cookie cultivate -S mix
+```

--- a/apps/wifi/README.md
+++ b/apps/wifi/README.md
@@ -13,12 +13,17 @@ The GenServer [WiFi.NetworkWrapper](lib/wifi/network_wrapper.ex) starts the WiFi
 
 Having to create a new firmware image just to change WiFi is (was) a royal pain, so this appliation supports not doing that:
 
-1. Connect to your (presumably) Pi. You can use with a keyboard with monitor but it's often easier to connect with [Screen](https://linux.die.net/man/1/screen) over USB:  connect your PI's USB and `ls /dev/tty*`, wait a few seconds, and connect to the device that just appeared. (It's `/dev/tty.usb[some number]` on my MacBook Pro).
+1. Connect to your (presumably) Pi. You can use with a keyboard with monitor but it's often easier to connect with [Screen](https://linux.die.net/man/1/screen) over USB:  connect your PI's USB and `ls /dev/tty*. Note that one USB input on the Pi Zero is power-only; use the one on the outside to connect. Also many USB cables are for charging only; use one that is known to also support data.
+1. Wait a few seconds, and connect to the device that just appeared. (It's `/dev/tty.usb[some number]` on my MacBook Pro).
 1. `Wifi.set("your ssid", "your secret")`
 
 That's it. See [lib/wifi.ex](lib/wifi.ex) for more details.
 
 Now this may be redundant with System.Registry - but ...
+
+## Knowing Wifi is set
+
+Until Wifi is set, Nerves Networking is super chatty at Log level `info` so that's a clue. The logs scrolling past, when connected over screen (or `picocom`) will tell you what's going on.
 
 
 ## Setting the time


### PR DESCRIPTION
Some instructions on setting up the WiFi. I hadn't really checked the timings and thought I'd have a day in the office before people went to Warsaw.

Note that it is always impossible to connect to conference / hotel WiFi as they use whatsit capture. You know - when a little webpage pops up and you need to enter a code.

You don't need an Internet connection so use a wireless router and make sure it's set up before the conference. Dan's old router is ok, but the Pi does tend to jump IP a lot. I meant to buy an Apple Airport Express, which I believe will work much better and take less space in luggage.

I was intending to order one delivered to the office, but actually it would be much easier if someone could pop into the Apple Store and pick one up.
